### PR TITLE
Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsonwebtoken": "^8.2.2",
     "lodash": "^4.17.15",
     "method-override": "^2.3.10",
-    "mongoose": "^5.7.0",
+    "mongoose": "^5.7.5",
     "morgan": "^1.9.1"
   },
   "devDependencies": {}

--- a/server/auth/routes.js
+++ b/server/auth/routes.js
@@ -25,6 +25,6 @@ router.get('/signin', decode(), (req, res, next) => {
 
 // LDAP sign-in. First, check for JWT (above)
 // if doesn't exist, redirect here for LDAP signin
-router.get('/ldap', authMiddleware, controller.ldap);
+router.all('/ldap', authMiddleware, controller.ldap);
 
 module.exports = router;


### PR DESCRIPTION
In cases of expired token, calls to LDAP were hitting 404 due to PUT rather than GET.

Updated mongoose to 5.7.5 due to CVE vulnerability